### PR TITLE
Fix this access on a collection that may trigger an array index out of bounds exception

### DIFF
--- a/src/.idea/.gitignore
+++ b/src/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/.idea/misc.xml
+++ b/src/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/src/.idea/modules.xml
+++ b/src/.idea/modules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/androidTest/androidTest.iml" filepath="$PROJECT_DIR$/androidTest/androidTest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/main/main.iml" filepath="$PROJECT_DIR$/main/main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/src.iml" filepath="$PROJECT_DIR$/.idea/src.iml" />
+    </modules>
+  </component>
+</project>

--- a/src/.idea/vcs.xml
+++ b/src/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/de/dennisguse/opentracks/Startup.java
+++ b/src/main/java/de/dennisguse/opentracks/Startup.java
@@ -63,7 +63,8 @@ public class Startup extends Application {
                 Class<?> activityThread = Class.forName("android.app.ActivityThread");
                 @SuppressLint("DiscouragedPrivateApi") Method getProcessName = activityThread.getDeclaredMethod("currentProcessName");
                 processName = (String) getProcessName.invoke(null);
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to retrieve process name", e);
             }
         } else {
             processName = Application.getProcessName();

--- a/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackListActivity.java
@@ -346,6 +346,9 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
      * @return true if handled.
      */
     private boolean handleContextItem(int itemId, long... longTrackIds) {
+        if(longTrackIds == null || longTrackIds.length == 0 ) {
+            return false;
+        }
         Track.Id[] trackIds = new Track.Id[longTrackIds.length];
         for (int i = 0; i < longTrackIds.length; i++) {
             trackIds[i] = new Track.Id(longTrackIds[i]);
@@ -364,10 +367,12 @@ public class TrackListActivity extends AbstractTrackDeleteActivity implements Co
         }
 
         if (itemId == R.id.list_context_menu_edit) {
-            Intent intent = IntentUtils.newIntent(this, TrackEditActivity.class)
-                    .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackIds[0]);
-            startActivity(intent);
-            return true;
+            if(trackIds.length > 0) {
+                Intent intent = IntentUtils.newIntent(this, TrackEditActivity.class)
+                        .putExtra(TrackEditActivity.EXTRA_TRACK_ID, trackIds[0]);
+                startActivity(intent);
+                return true;
+            }
         }
 
         if (itemId == R.id.list_context_menu_delete) {

--- a/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
+++ b/src/main/java/de/dennisguse/opentracks/chart/ChartView.java
@@ -883,7 +883,7 @@ public class ChartView extends View {
                 break;
             }
         }
-        if (firstChartValueSeries != null && chartPoints.size() > 0) {
+        if (firstChartValueSeries != null && !chartPoints.isEmpty()) {
             int dx = getX(maxX) - pointer.getIntrinsicWidth() / 2;
             double value = firstChartValueSeries.extractDataFromChartPoint(last);
             int dy = getY(firstChartValueSeries, value) - pointer.getIntrinsicHeight();


### PR DESCRIPTION
**Pull Request Title:**
Fix Potential ArrayIndexOutOfBoundsException in handleContextItem()

**Summary**
Fixed a potential ArrayIndexOutOfBoundsException in the handleContextItem() method.
Added a check to ensure trackIds is not accessed when empty, improving code robustness.

**Why This Change?**
Accessing trackIds[0] without verifying its length could lead to runtime crashes.
Ensuring the array isn’t empty before accessing prevents unexpected errors and improves code reliability.

**Impact**
Enhances code stability and maintainability by preventing possible crashes.
No functional impact—this change focuses solely on better error handling and preventing edge-case issues.